### PR TITLE
Add auto loading feature.

### DIFF
--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -1,0 +1,22 @@
+<?php
+
+spl_autoload_register(function($class) 
+{
+    // If class does not exist, we will attempt to find
+	// at two places (include and classes folder)
+	$base = dirname(__DIR__);
+	$folders = array(
+		"includes" => $base . "/includes/",
+		"classes" => $base . "/classes/"
+	);
+	
+    foreach($folders as $path) {
+        $file = $path . $class . '.php';
+        if (file_exists($file)) {
+            include_once($file);
+            break;
+        }
+    }
+});
+
+?>

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,4 +1,5 @@
 <?php
+include_once(__DIR__ . "/autoload.php");
 
 $config = array( 'dbname' => 'autocode',
 				 'dbusername' => 'root',


### PR DESCRIPTION
I have added the auto loading feature. You do not need to include the files just to use their class now. Auto loading will try to discover which file to include in order for class to work. For example: in your `\login\index.php` files, you can remove

    include '../includes/DatabaseConnect.php';
    include '../includes/Authenticate.php'

and it will still work. How does auto loading work?

When you call a class that does not exist in your code, Let say you are calling a class `Authenticate`. You haven't included `Authenticate.php` yet. The auto loading will try to find `Authenticate.php` in folder `includes` or `classes`. If there is filename `Authenticate.php`, it will auto include for you.